### PR TITLE
🍉 238 bytes

### DIFF
--- a/fft1D/index.html
+++ b/fft1D/index.html
@@ -16,7 +16,7 @@
 // Golf starts here
 // =================
 
-FFT=(F,h=F.length/2,t,a=[],o=[],P,M,T)=>{for(t=h*2;t--;)(t&1?o:a)[t>>1]=F[t];for(h>1&&(FFT(a),FFT(o)),t=h;t--;)with(Math)M=cos(P=-PI*t/h)*o[t][0]-sin(P)*o[t][1],T=cos(P)*o[t][1]+sin(P)*o[t][0],F[t]=[a[t][0]+M,a[t][1]+T],F[t+h]=[a[t][0]-M,a[t][1]-T]}
+FFT=(F,M,T,b,p,h=F.length/2,t,a=[],o=[])=>{for(t=h*2;t--;)(t&1?o:a)[t>>1]=F[t];for(h>1&&FFT(o,FFT(a)),t=h;t--;)with(Math)p=o[t],b=a[t],M=cos(T=PI*t/h)*p[0]+sin(T)*p[1],T=cos(T)*p[1]-sin(T)*p[0],F[t]=[b[0]+M,b[1]+T],F[t+h]=[b[0]-M,b[1]-T]}
 
 
 // Golf ends here


### PR DESCRIPTION
- Shuffle the args so we can nest the calls to `FFT(o)` and `FFT(a)`
- Use `b,p` to shorten `a[t]` and `o[t]` 
- Use the fact that `cos(x) === cos(-x)` and `sin(x) === -sin(-x)` to change the sign of P, and save one byte 
- Get rid of P, using T instead