### PR TITLE
🚒 219 bytes

### DIFF
--- a/fft1D/index.html
+++ b/fft1D/index.html
@@ -16,7 +16,7 @@
 // Golf starts here
 // =================
 
-FFT=(F,M,T,b,p,t=F.length,h=t/2,a=[],o=[])=>{for(;t--;)(t&1?o:a)[t>>1]=F[t];for(h>1&&FFT(o,FFT(a)),t=h;t--;)with(Math)p=o[t],b=a[t],M=cos(T=PI*t/h)*p[0]+sin(T)*p[1],T=cos(T)*p[1]-sin(T)*p[0],F[t]=[b[0]+M,b[1]+T],F[t+h]=[b[0]-M,b[1]-T]}
+FFT=(F,M,T,p,q,t=F.length,h=t/2,a=[],o=[])=>{for(;t--;)(t&1?o:a)[t>>1]=F[t];for(h>1&&FFT(o,FFT(a)),t=h;t--;)with(Math)[p,q]=o[t],M=cos(T=PI*t/h)*p+sin(T)*q,T=cos(T)*q-sin(T)*p,[p,q]=a[t],F[t]=[p+M,q+T],F[t+h]=[p-M,q-T]}
 
 // Golf ends here
 // ==============


### PR DESCRIPTION
- Remove 2 variables since we don't need to use `o[t][..]` and `a[t][...]` in the same calculations
- Spread `o[t]`, and `b[t]`