### PR TITLE
207: Abuse for ... of  assignment expression

### DIFF
--- a/fft1D/index.html
+++ b/fft1D/index.html
@@ -16,7 +16,7 @@
 // Golf starts here
 // =================
 
-FFT=(F,M,T,p,q,t=F.length,h=t/2,a=[],o=[])=>{for(;t--;)(t&1?o:a)[t>>1]=F[t];for(h>1&&FFT(o,FFT(a)),t=h;t--;)with(Math)[p,q]=o[t],M=cos(T=PI*t/h)*p+sin(T)*q,T=cos(T)*q-sin(T)*p,[p,q]=a[t],F[t]=[p+M,q+T],F[t+h]=[p-M,q-T]}
+FFT=(F,M,T,p,q,t,h=0,a=[],o=[])=>{for(((t=~t)?a:o)[h]of F)h+=!t;for(h>1&&FFT(o,FFT(a)),t=h;t--;)with(Math)[p,q]=o[t],M=cos(T=PI*t/h)*p+sin(T)*q,T=cos(T)*q-sin(T)*p,[p,q]=a[t],F[t]=[p+M,q+T],F[t+h]=[p-M,q-T]}
 
 // Golf ends here
 // ==============


### PR DESCRIPTION
We're used to the fact `a` in `for(a of iterable)` is usually a variable, but actually it can be any AssignmentExpression LHS.

It help to get rid of the explicit `.length` and also the array iteration is now forwards: leaving the `h = F.length / 2` after the last iteration